### PR TITLE
fixes tests and adds support for multi-line content

### DIFF
--- a/lib/vdata-parser.js
+++ b/lib/vdata-parser.js
@@ -12,6 +12,7 @@ var parser = module.exports = {};
 function parse (lines) {
     var block,
         subLines = [],
+		key,
         data = {};
 
     // check if lines are an array
@@ -58,11 +59,20 @@ function parse (lines) {
                 // push current line to sublines array
                 subLines.push(line);
             } else {
-                // detect key/value seperator
-                var sep = line.indexOf(':');
+                // if line begins with a space
+                if (line.match(/^\ /)) {
+                    // add on to the previous value
+                    data[key] += line.substr(1);
+                } else {
+                    // detect key/value seperator
+                    var sep = line.indexOf(':');
 
-                // set key and value
-                data[line.substr(0, sep)] = line.substr(sep + 1);
+                    key = line.substr(0, sep);
+                    var value = line.substr(sep + 1);
+
+                    // set key and value
+                    data[key] = value;
+                }
             }
         }
     }

--- a/test/test-files/dummy.vdata
+++ b/test/test-files/dummy.vdata
@@ -2,7 +2,8 @@ BEGIN:MESSAGE
 NAME:Hello World
 BEGIN:LANGUAGE
 KEY:English
-NAME:Hello World
+NAME:Hello W
+ orld
 END:LANGUAGE
 BEGIN:LANGUAGE
 KEY:German

--- a/test/vdata-parser_test.js
+++ b/test/vdata-parser_test.js
@@ -31,7 +31,7 @@ var dummy = "" +
     "NAME:Hello World\n" +
     "BEGIN:LANGUAGE\n" +
         "KEY:English\n" +
-        "NAME:Hello World\n" +
+        "NAME:Hello W\n orld\n" +
     "END:LANGUAGE\n" +
     "BEGIN:LANGUAGE\n" +
         "KEY:German\n" +


### PR DESCRIPTION
This pull request updates the tests to use JSON.stringify() instead of JSON.toString(). Using toString() returns the JSON library as a string, '[object JSON]', not the JSON string of the parameter, so the tests where never failing.

This pull request also adds support for multi-line content as mentioned in the [spec](http://tools.ietf.org/html/rfc5545); ([3.1](http://tools.ietf.org/html/rfc5545#section-3.1)) defines the ability to have a single content line that is "folded" over multiple lines.

Tests have been added and the library has been updated to support multi-line content.
